### PR TITLE
Modify after the page is loaded completely

### DIFF
--- a/revert-github-dark-navbar.user.js
+++ b/revert-github-dark-navbar.user.js
@@ -6,7 +6,7 @@
 // @match        https://github.com/*
 // @match        https://gist.github.com/*
 // @grant        none
-// @run-at       document-start
+// @run-at       document-idle
 // ==/UserScript==
 
 var headers = document.getElementsByClassName("header");


### PR DESCRIPTION
document-start is run when the page starts loading, the header may not have been rendered by then... This can result in the header not being modified.

This change fixes it by running after all the assets have been loaded.